### PR TITLE
EbnfGrammarParserToken.combinatorForFile

### DIFF
--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/EbnfGrammarParserToken.java
@@ -102,6 +102,20 @@ public final class EbnfGrammarParserToken extends EbnfParentParserToken<EbnfGram
         );
     }
 
+    /**
+     * Identical in functionality to {@link #combinator(Function, EbnfParserCombinatorSyntaxTreeTransformer)}, except the function return will throw if the parser requested is not found.
+     */
+    public <C extends ParserContext> Function<EbnfIdentifierName, Parser<C>> combinatorForFile(final Function<EbnfIdentifierName, Optional<Parser<C>>> identifierToParser,
+                                                                                               final EbnfParserCombinatorSyntaxTreeTransformer<C> transformer,
+                                                                                               final String filename) {
+        return EbnfParserCombinators.transformForFile(
+                this,
+                identifierToParser,
+                transformer,
+                filename
+        );
+    }
+
     // children.........................................................................................................
 
     @Override

--- a/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinators.java
+++ b/src/main/java/walkingkooka/text/cursor/parser/ebnf/combinator/EbnfParserCombinators.java
@@ -18,6 +18,7 @@
 package walkingkooka.text.cursor.parser.ebnf.combinator;
 
 import walkingkooka.reflect.PublicStaticHelper;
+import walkingkooka.text.CharSequences;
 import walkingkooka.text.cursor.parser.Parser;
 import walkingkooka.text.cursor.parser.ParserContext;
 import walkingkooka.text.cursor.parser.ebnf.EbnfGrammarParserToken;
@@ -66,6 +67,26 @@ public final class EbnfParserCombinators implements PublicStaticHelper {
         context.fixProxyParsers();
 
         return context.nameToParser();
+    }
+
+    /**
+     * Accepts a {@link EbnfGrammarParserToken} and function that may be used to query parsers given an {@link EbnfIdentifierName}.
+     */
+    public static <C extends ParserContext> Function<EbnfIdentifierName, Parser<C>> transformForFile(final EbnfGrammarParserToken grammar,
+                                                                                                     final Function<EbnfIdentifierName, Optional<Parser<C>>> identifierToParser,
+                                                                                                     final EbnfParserCombinatorSyntaxTreeTransformer<C> transformer,
+                                                                                                     final String filename) {
+        Objects.requireNonNull(grammar, "grammar");
+        Objects.requireNonNull(identifierToParser, "identifierToParser");
+        Objects.requireNonNull(transformer, "syntaxTreeTransformer");
+        CharSequences.failIfNullOrEmpty(filename, "filename");
+
+        return (n) -> transform(
+                grammar,
+                identifierToParser,
+                transformer
+        ).apply(n)
+                .orElseThrow(() -> new EbnfParserCombinatorException("Missing parser " + CharSequences.quoteAndEscape(n.value()) + " in " + CharSequences.quoteAndEscape(filename)));
     }
 
     /**


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-text-cursor-parser-ebnf/issues/109
- Add a helper which wraps the Function<EbnfIndentifierName, Optional<Parser>> and throws if the parser is missing